### PR TITLE
Fix grid on backspace

### DIFF
--- a/src/grid/grid.js
+++ b/src/grid/grid.js
@@ -22,9 +22,13 @@ export const getOtherRowCol = (row, col) => {
   return [GRID_SIZE-row-1, GRID_SIZE-col-1];
 }
 
+const skipDueToFixedGrid = (fixedGrid, currentValue, newValue) => {
+  return (fixedGrid && (newValue === '.' || currentValue === '.'))
+}
+
 export const placeValue = (grid, row, col, value, fixedGrid) => {
   console.log('fixed grid', fixedGrid, 'val:', grid[row][col]);
-  if(fixedGrid && (grid[row][col] === '.' || value === '.')) {
+  if (skipDueToFixedGrid(fixedGrid, grid[row][col], value)) {
     return grid;
   }
   let newGrid = Immutable.fromJS(grid).toJS();

--- a/src/reducers/crossword.js
+++ b/src/reducers/crossword.js
@@ -69,7 +69,7 @@ const crossword = (state = initialCrosswordState, action) => {
 
     case 'MOVE_GRID_BACK':
     {
-      const newGrid = gridUtils.placeValue(grid, row, col, ' ');
+      const newGrid = gridUtils.placeValue(grid, row, col, ' ', fixGrid);
       const delta = DIR_TO_DELTA[oppositeDirection(direction)];
       const newCursor = moveCursor(delta, [row, col]);
       return {


### PR DESCRIPTION
Make sure to consider fixGrid when backspace is
pressed - existing black squares should not be
deleted.